### PR TITLE
Инкремент 6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,15 @@ test_iter5::  build test_iter1 test_iter2 test_iter3 test_iter4
     	-server-port=$(SERVER_PORT) \
     	-source-path=.
 
+test_iter6::  build test_iter1 test_iter2 test_iter3 test_iter4
+	SERVER_PORT=$(SERVER_PORT)\
+	ADDRESS="localhost:$(SERVER_PORT)" \
+    	TEMP_FILE=$(shell random tempfile) \
+    	metricstest -test.v -test.run=^TestIteration6$ \
+    	-agent-binary-path=cmd/agent/agent \
+    	-binary-path=cmd/server/server \
+    	-server-port=$(SERVER_PORT) \
+    	-source-path=.
 
 test::
 	go test ./...

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,22 +5,33 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/iudanet/yp-metrics-go/internal/config"
+	"github.com/iudanet/yp-metrics-go/internal/logger"
 	"github.com/iudanet/yp-metrics-go/internal/server"
 	"github.com/iudanet/yp-metrics-go/internal/storage"
+	"go.uber.org/zap"
 )
 
+var sugar zap.SugaredLogger
+
 func main() {
+	newLogger, err := logger.New("Info")
+	if err != nil {
+		// вызываем панику, если ошибка
+		panic(err)
+	}
+
+	// делаем регистратор SugaredLogger
 	storage := storage.NewStorage()
 	cfg := config.ParseServerFlags()
-	svc := server.NewService(storage, cfg)
+	svc := server.NewService(storage, cfg, newLogger)
 	// chi отключен для проходждения тестов. хотел сделать с нативным новым роутером.
 	_ = chi.NewRouter()
 	m := http.NewServeMux()
 	m.HandleFunc(`POST /update/{typeMetrics}/{name}/{value}`, svc.UpdateMetric)
 	m.HandleFunc(`GET /value/{typeMetrics}/{name}`, svc.GetMetric)
 	m.HandleFunc(`GET /{$}`, svc.GetIndex)
-
-	err := http.ListenAndServe(cfg.MetricServerHost, m)
+	newLogger.Info("Running server", zap.String("address", cfg.MetricServerHost))
+	err = http.ListenAndServe(cfg.MetricServerHost, svc.WithLogging(m))
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.24.1
 require (
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/stretchr/testify v1.10.0
+	go.uber.org/zap v1.27.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,12 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,23 @@
+package logger
+
+import (
+	"go.uber.org/zap"
+)
+
+func New(level string) (*zap.Logger, error) {
+	lvl, err := zap.ParseAtomicLevel(level)
+	if err != nil {
+		return nil, err
+	}
+	// создаём новую конфигурацию логера
+	cfg := zap.NewProductionConfig()
+	// устанавливаем уровень
+	cfg.Level = lvl
+	// создаём логер на основе конфигурации
+	zl, err := cfg.Build()
+	if err != nil {
+		return nil, err
+	}
+
+	return zl, nil
+}

--- a/internal/server/midelvare.go
+++ b/internal/server/midelvare.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// берём структуру для хранения сведений об ответе
+type responseData struct {
+	status int
+	size   int
+}
+
+// добавляем реализацию http.ResponseWriter
+type loggingResponseWriter struct {
+	http.ResponseWriter // встраиваем оригинальный http.ResponseWriter
+	responseData        *responseData
+}
+
+func (r *loggingResponseWriter) Write(b []byte) (int, error) {
+	// записываем ответ, используя оригинальный http.ResponseWriter
+	size, err := r.ResponseWriter.Write(b)
+	r.responseData.size += size // захватываем размер
+	return size, err
+}
+
+func (r *loggingResponseWriter) WriteHeader(statusCode int) {
+	// записываем код статуса, используя оригинальный http.ResponseWriter
+	r.ResponseWriter.WriteHeader(statusCode)
+	r.responseData.status = statusCode // захватываем код статуса
+}
+
+func (s *service) WithLogging(h http.Handler) http.Handler {
+	logFn := func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		responseData := &responseData{
+			status: 0,
+			size:   0,
+		}
+		lw := loggingResponseWriter{
+			ResponseWriter: w, // встраиваем оригинальный http.ResponseWriter
+			responseData:   responseData,
+		}
+		h.ServeHTTP(&lw, r) // внедряем реализацию http.ResponseWriter
+
+		duration := time.Since(start)
+
+		s.logger.Info("request",
+			zap.String("uri", r.RequestURI),
+			zap.String("method", r.Method),
+			zap.Int("status", responseData.status), // получаем перехваченный код статуса ответа
+			zap.Duration("duration", duration),
+			zap.Int("size", responseData.size), // получаем перехваченный размер ответа
+		)
+	}
+	return http.HandlerFunc(logFn)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,13 +9,15 @@ import (
 
 	"github.com/iudanet/yp-metrics-go/internal/config"
 	"github.com/iudanet/yp-metrics-go/internal/storage"
+	"go.uber.org/zap"
 )
 
-func NewService(storage storage.Repository, cfg *config.ServerConfig) *service {
+func NewService(storage storage.Repository, cfg *config.ServerConfig, logger *zap.Logger) *service {
 	return &service{
 		storage: storage,
 		viewer:  storage,
 		config:  cfg,
+		logger:  logger,
 	}
 }
 
@@ -23,6 +25,7 @@ type service struct {
 	storage storage.MetricWriter
 	viewer  storage.MetricReader
 	config  *config.ServerConfig
+	logger  *zap.Logger
 }
 type IndexData struct {
 	Counters map[string]int64

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/iudanet/yp-metrics-go/internal/config"
+	"github.com/iudanet/yp-metrics-go/internal/logger"
 	"github.com/iudanet/yp-metrics-go/internal/storage"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,11 +59,14 @@ func TestUpdateMetric(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			newLogger, err := logger.New("Info")
+			assert.NoError(t, err)
+
 			store := storage.NewStorage()
 			cfg := &config.ServerConfig{
 				MetricServerHost: "localhost:8080",
 			}
-			svc := NewService(store, cfg)
+			svc := NewService(store, cfg, newLogger)
 
 			req := httptest.NewRequest(http.MethodPost, tt.urlPath, nil)
 			req.Header.Set("Content-Type", tt.contentType)
@@ -88,7 +92,10 @@ func TestUpdateMetric(t *testing.T) {
 func TestUpdateMetricSuccess(t *testing.T) {
 	store := storage.NewStorage()
 	cfg := config.NewServerConfig()
-	svc := NewService(store, cfg)
+	newLogger, err := logger.New("Info")
+	assert.NoError(t, err)
+
+	svc := NewService(store, cfg, newLogger)
 
 	tests := []struct {
 		name       string

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"errors"
+	"maps"
 	"sync"
 
 	"github.com/iudanet/yp-metrics-go/internal/utils"
@@ -86,7 +87,10 @@ func (m *memStorage) GetMapCounter() (map[string]int64, error) {
 func (m *memStorage) GetMapGauge() (map[string]float64, error) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
-	return m.gauge, nil
+	// return map возвращает ссылку. надо ккопировать map или обрабатывать range через мютекс
+	copyMapGauge := make(map[string]float64)
+	maps.Copy(copyMapGauge, m.gauge)
+	return copyMapGauge, nil
 }
 
 func (m *memStorage) GetCounter(name string) (int64, error) {


### PR DESCRIPTION
- Implement request logging middleware with zap logger
- Add test_iter6 target to Makefile for iteration 6 tests
- Copy gauge map to prevent data races
- Initialize logger in server main and pass to service
- Add zap logger dependency to go.mod